### PR TITLE
php 8 changes  in full.php and rbac.php causes issue in function descendants($ID)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 .settings
 .buildpath
 .project
+.idea
 *bak*
 *draft*
 *phprbac.sqlite3*
 *Doxygen*
 *phpdoc*
 index.php
+vendor
+/composer.lock

--- a/PhpRbac/src/PhpRbac/core/lib/nestedset/full.php
+++ b/PhpRbac/src/PhpRbac/core/lib/nestedset/full.php
@@ -221,11 +221,12 @@ class FullNestedSet extends BaseNestedSet implements ExtendedNestedSet
      * @param boolean $AbsoluteDepths to return Depth of sub-tree from zero or absolutely from the whole tree
      * @param string $Condition
      * @param string $Rest optional, rest of variables to fill in placeholders of condition string, one variable for each ? in condition
-	 * @return Rowset including Depth field
-	 * @seealso children
+     * @return Rowset including Depth field
+     * @seealso children
      */
-    function descendantsConditional($ConditionString,$Rest=null,$AbsoluteDepths=false)
+    function descendantsConditional($ConditionString,$AbsoluteDepths=false,$Rest=null)
     {
+        $DepthConcat = "";
         if (!$AbsoluteDepths)
             $DepthConcat="- (sub_tree.innerDepth )";
         $Arguments=func_get_args();

--- a/PhpRbac/src/PhpRbac/core/lib/rbac.php
+++ b/PhpRbac/src/PhpRbac/core/lib/rbac.php
@@ -334,7 +334,7 @@ abstract class BaseRbac extends JModel
 	 */
 	function descendants($ID)
 	{
-		$res = $this->{$this->type ()}->descendantsConditional("ID=?", $ID, /* absolute depths*/false);
+        $res = $this->{$this->type()}->descendantsConditional("ID=?", false, $ID);
 		$out = array ();
 		if (is_array ( $res ))
 			foreach ( $res as $v )


### PR DESCRIPTION
# descendants issue

in function descendants($ID) the parameter $ID is set and causes issue in 

$res = $this->{$this->type()}->descendantsConditional("ID=?", $ID, false);

$ID is interpreted as depth since 

in PhpRbac/src/PhpRbac/core/lib/nestedset/full.php

it is set this way:

function descendantsConditional($ConditionString,$AbsoluteDepths=false);

=> recommand to make depth 2nd parameter to match with line 15 of PhpRbac/src/PhpRbac/core/lib/nestedset/full.php

1. Condition
2. Depht
3. Rest

(WIP, should be also considered in function siblingConditional) 

# add omit in gitignore for jetbrains, vendor, composer.lock